### PR TITLE
add a url share item

### DIFF
--- a/RNShare.m
+++ b/RNShare.m
@@ -16,8 +16,10 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options)
     // Your implementation here
     NSString *shareText = [RCTConvert NSString:options[@"share_text"]];
     NSString *shareUrl = [RCTConvert NSString:options[@"share_URL"]];
+    //some app extension need a NSURL or UIImage Object to share
+    NSURL *cardUrl = [NSURL URLWithString:shareUrl];
     
-    NSArray *itemsToShare = @[shareText, shareUrl];
+    NSArray *itemsToShare = @[shareText, shareUrl,cardUrl];
     UIActivityViewController *activityVC = [[UIActivityViewController alloc] initWithActivityItems:itemsToShare applicationActivities:nil];
     /*activityVC.excludedActivityTypes = @[UIActivityTypePostToWeibo,
                                          UIActivityTypeMessage,


### PR DESCRIPTION
Add a Url or Image Object item because some App's extension need . otherwise they won't appear in the share sheet  on iOS .
Also i have no idea about  share a Url using Intent in android.  any idea? 