### PR TITLE
Remove peerDependecies and unnecessary dependency

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -6,7 +6,6 @@
 
 var { NativeModules } = require('react-native');
 var NativeRNShare = NativeModules.RNShare;
-var invariant = require('invariant');
 
 /**
  * High-level docs for the RNShare iOS API can be written here.

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "email": "efuentealba@json.cl"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "react-native": ">= 0.13.0"
-  },
   "readmeFilename": "README.md",
   "dependencies": {
     "invariant": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,5 @@
     "email": "efuentealba@json.cl"
   },
   "license": "MIT",
-  "readmeFilename": "README.md",
-  "dependencies": {
-    "invariant": "^2.2.0"
-  }
+  "readmeFilename": "README.md"
 }


### PR DESCRIPTION
`peerDependecies` is blocking to use this package out of the box with "rc" version of React Native (eg. 0.19.0-rc)

`invariant` dependency is imported but never used.