### PR TITLE
Add Subject for email sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ import Share from 'react-native-share';
 class Example extends Component {
   onShare() {
     Share.open({
+      share_subject: "email subject",
       share_text: "Hola mundo",
       share_URL: "http://google.cl",
       title: "Share Link"
@@ -112,6 +113,8 @@ const styles = StyleSheet.create({
 
 AppRegistry.registerComponent('Example', () => Example);
 ```
+
+NOTE: If both share_text and share_url are provided share_url will be concatenated to the end of share_text to form the body of the message. If only one is provided it will be used
 
 ## how it looks:
 ![Demo Android](/assets/android.png)

--- a/android/src/main/java/cl/json/RNShareModule.java
+++ b/android/src/main/java/cl/json/RNShareModule.java
@@ -46,14 +46,17 @@ public class RNShareModule extends ReactContextBaseJavaModule {
     Intent intent = new Intent(android.content.Intent.ACTION_SEND);
     intent.setType("text/plain");
 
-    if (hasValidKey("share_text", options)) {
-      intent.putExtra(Intent.EXTRA_SUBJECT, options.getString("share_text"));
+    if (hasValidKey("share_subject", options) ) {
+      intent.putExtra(Intent.EXTRA_SUBJECT, options.getString("share_subject"));
     }
 
-    if (hasValidKey("share_URL", options)) {
+    if (hasValidKey("share_text", options) && hasValidKey("share_URL", options)) {
+      intent.putExtra(Intent.EXTRA_TEXT, options.getString("share_text") + " " + options.getString("share_URL"));
+    } else if (hasValidKey("share_URL", options)) {
       intent.putExtra(Intent.EXTRA_TEXT, options.getString("share_URL"));
+    } else if (hasValidKey("share_text", options) ) {
+      intent.putExtra(Intent.EXTRA_TEXT, options.getString("share_text"));
     }
-
     return intent;
   }
 

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -18,6 +18,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options :(RCTResponseSenderBlock)callback
     // Your implementation here
     NSString *shareText = [RCTConvert NSString:options[@"share_text"]];
     NSString *shareUrl = [RCTConvert NSString:options[@"share_URL"]];
+    NSString *shareSubject = [RCTConvert NSString:options[@"share_subject"]];
     //some app extension need a NSURL or UIImage Object to share
     NSURL *cardUrl = [NSURL URLWithString:shareUrl];
 
@@ -35,6 +36,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options :(RCTResponseSenderBlock)callback
                                          UIActivityTypePostToVimeo,
                                          UIActivityTypePostToTencentWeibo,
                                          UIActivityTypeAirDrop];*/
+    [activityVC setValue:shareSubject forKey:@"subject"];
     UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     
     //if iPhone


### PR DESCRIPTION
This also concats URL onto the end of share_text if both are provided on Android. The result means the message sent from Android & iOS now match.