### PR TITLE
Sharing content uris

### DIFF
--- a/android/src/main/java/cl/json/RNShareModule.java
+++ b/android/src/main/java/cl/json/RNShareModule.java
@@ -46,7 +46,8 @@ public class RNShareModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void open(ReadableMap options, @Nullable Callback failureCallback, @Nullable Callback successCallback) {
         try{
-            this.sharesExtra.get("generic").open(options);
+            GenericShare share = new GenericShare(this.reactContext);
+            share.open(options);
             successCallback.invoke("OK");
         }catch(ActivityNotFoundException ex) {
             System.out.println("ERROR");

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -40,7 +40,7 @@ public class ShareFile {
      * @return {@link String} mime type
      */
     private String getMimeType(String url) {
-        String type = "*/*";
+        String type = null;
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
         if (extension != null) {
             type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
@@ -63,8 +63,18 @@ public class ShareFile {
     }
     public boolean isLocalFile() {
         if(uri.getScheme().equals("content") || uri.getScheme().equals("file")) {
-            String realPath = this.getRealPathFromURI(uri);
-            this.type = this.getMimeType(realPath);
+            // try to get mimetype from uri
+            this.type = this.getMimeType(uri.toString());
+
+            // try resolving the file and get the mimetype
+            if(this.type == null) {
+              String realPath = this.getRealPathFromURI(uri);
+              this.type = this.getMimeType(realPath);
+            }
+
+            if(this.type == null) {
+              this.type = "*/*";
+            }
 
             return true;
         }

--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -39,6 +39,7 @@ public abstract class ShareIntent {
                 this.getIntent().setType(fileShare.getType());
                 this.getIntent().putExtra(Intent.EXTRA_STREAM, uriFile);
                 this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("message"));
+                this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             } else {
                 this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("message") + " " + options.getString("url"));
             }
@@ -48,6 +49,7 @@ public abstract class ShareIntent {
                 Uri uriFile = fileShare.getURI();
                 this.getIntent().setType(fileShare.getType());
                 this.getIntent().putExtra(Intent.EXTRA_STREAM, uriFile);
+                this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             } else {
                 this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("url"));
             }


### PR DESCRIPTION
Allow other kinds of contentUris to be shared, not just from the library, therefore try to get the extension/mime-type from the contentUri itself. Also grant read permissions for sent contentUris.