### PR TITLE
Allow to pass file mime type as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Supported options:
 | Name  | Type     | Description |
 | :---- | :------: | :--- |
 | url | string   | URL you want to share (you can share a base64 file url only in iOS & Android ) |
+| type | string   | File mime type (optional) |
 | message | string   |  |
 | title | string   |  (optional) |
 | subject | string   | (optional) |
@@ -75,6 +76,7 @@ Supported options:
 | Name  | Type     | Description |
 | :---- | :------: | :--- |
 | url | string   | URL you want to share |
+| type | string   | File mime type (optional) |
 | message | string   |  |
 | title | string   |  (optional) |
 | subject | string   | (optional) |

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -26,8 +26,13 @@ public class ShareFile {
     private final ReactApplicationContext reactContext;
     private String url;
     private Uri uri;
-    private String type = "*/*";
+    private String type;
     private String extension = "";
+
+    public ShareFile(String url, String type, ReactApplicationContext reactContext){
+        this(url, reactContext);
+        this.type = type;
+    }
 
     public ShareFile(String url, ReactApplicationContext reactContext){
         this.url = url;
@@ -63,6 +68,10 @@ public class ShareFile {
     }
     public boolean isLocalFile() {
         if(uri.getScheme().equals("content") || uri.getScheme().equals("file")) {
+            // type is already set
+            if (this.type != null) {
+                return true;
+            }
             // try to get mimetype from uri
             this.type = this.getMimeType(uri.toString());
 
@@ -81,6 +90,9 @@ public class ShareFile {
         return false;
     }
     public String getType() {
+        if (this.type == null) {
+           return "*/*";
+        }
         return this.type;
     }
     private String getRealPathFromURI(Uri contentUri) {
@@ -96,7 +108,7 @@ public class ShareFile {
     public Uri getURI() {
 
         final MimeTypeMap mime = MimeTypeMap.getSingleton();
-        this.extension = mime.getExtensionFromMimeType(this.type);
+        this.extension = mime.getExtensionFromMimeType(getType());
         if(this.isBase64File()) {
             String encodedImg = this.uri.getSchemeSpecificPart().substring(this.uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
             try {

--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -33,7 +33,7 @@ public abstract class ShareIntent {
         }
 
         if (ShareIntent.hasValidKey("message", options) && ShareIntent.hasValidKey("url", options)) {
-            ShareFile fileShare = new ShareFile(options.getString("url"), this.reactContext);
+            ShareFile fileShare = getFileShare(options);
             if(fileShare.isFile()) {
                 Uri uriFile = fileShare.getURI();
                 this.getIntent().setType(fileShare.getType());
@@ -44,7 +44,7 @@ public abstract class ShareIntent {
                 this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("message") + " " + options.getString("url"));
             }
         } else if (ShareIntent.hasValidKey("url", options)) {
-            ShareFile fileShare = new ShareFile(options.getString("url"), this.reactContext);
+            ShareFile fileShare = getFileShare(options);
             if(fileShare.isFile()) {
                 Uri uriFile = fileShare.getURI();
                 this.getIntent().setType(fileShare.getType());
@@ -55,6 +55,13 @@ public abstract class ShareIntent {
             }
         } else if (ShareIntent.hasValidKey("message", options) ) {
             this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("message"));
+        }
+    }
+    protected ShareFile getFileShare(ReadableMap options) {
+        if (ShareIntent.hasValidKey("type", options)) {
+            return new ShareFile(options.getString("url"), options.getString("type"), this.reactContext);
+        } else {
+            return new ShareFile(options.getString("url"), this.reactContext);
         }
     }
     protected static String urlEncode(String param) {


### PR DESCRIPTION
On Android (6.0), for some reason that I can't explain, when the mime type of a local file cannot be guessed from its URL I get a `NullPointerException` at https://github.com/EstebanFuentealba/react-native-share/blob/92aaa3f87e88377cdc74c6b272e5b37543473c4a/android/src/main/java/cl/json/ShareFile.java#L90

This happens for instance with files like `myImage.JPG` (case issue), `myFile` (no extension) or `myMarkdown.md` (unknown extension), for which `ShareFile#getMimeType` returns `null`, thus the call to `ShareFile#getRealPathFromURI` in `ShareFile#isLocalFile`.

Note that I download and store files with [react-native-fetch-blob](https://github.com/wkh237/react-native-fetch-blob) configured to use the Android DownloadManager. An example of storage location is `file:///data/user/0/com.android.providers.downloads/cache/myPDFFile.pdf`.

The purpose of this pull request is to allow to explicitely pass the mime type in the options when sharing a local file:

    Share.open({
      url: fileURL,
      type: fileMimeType,
    }

This definitley solves my issue and I believe it can be useful when knowing the mime type of a local file at the moment we need to share it.

PS: looking at #62, I wonder if @logileifs wasn't facing the same issue, so might be linked.

Thanks!