### PR TITLE
Add promise rejection on iOS if app not installed

### DIFF
--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -47,8 +47,13 @@
         UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
         [ctrl presentViewController:composeController animated:YES completion:Nil];
     } else {
-        NSLog(@"No installed");
-        //  TODO: Add web url share
+      NSString *errorMessage = @"Not installed";
+      NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+      NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+
+      NSLog(errorMessage);
+      failureCallback(error);
+      //  TODO: Add web url share
     }
 
 

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -23,11 +23,17 @@
         if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
             [[UIApplication sharedApplication] openURL: whatsappURL];
         } else {
-            // Cannot open whatsapp
-            NSLog(@"No installed");
-            NSString *stringURL = @"http://itunes.apple.com/en/app/whatsapp-messenger/id310633997";
-            NSURL *url = [NSURL URLWithString:stringURL];
-            [[UIApplication sharedApplication] openURL:url];
+          // Cannot open whatsapp
+          NSString *stringURL = @"http://itunes.apple.com/en/app/whatsapp-messenger/id310633997";
+          NSURL *url = [NSURL URLWithString:stringURL];
+          [[UIApplication sharedApplication] openURL:url];
+
+          NSString *errorMessage = @"Not installed";
+          NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+          NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+
+          NSLog(errorMessage);
+          failureCallback(error);
         }
     }
 


### PR DESCRIPTION
Adding promise rejection for whatsapp and generic apps on ios.  Don't need to do for email or google plus since they don't rely on specific apps being installed.