### PR TITLE
Add promise success for singleShare on iOS

### DIFF
--- a/ios/EmailShare.m
+++ b/ios/EmailShare.m
@@ -39,10 +39,10 @@
 
         if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
             [[UIApplication sharedApplication] openURL: whatsappURL];
+            successCallback(@[]);
         } else {
             // Cannot open email
             NSLog(@"Cannot open email");
-            
         }
     }
 

--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -46,6 +46,7 @@
 
         UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
         [ctrl presentViewController:composeController animated:YES completion:Nil];
+        successCallback(@[]);
     } else {
       NSString *errorMessage = @"Not installed";
       NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};

--- a/ios/GooglePlusShare.m
+++ b/ios/GooglePlusShare.m
@@ -12,15 +12,16 @@
 - (void)shareSingle:(NSDictionary *)options
     failureCallback:(RCTResponseErrorBlock)failureCallback
     successCallback:(RCTResponseSenderBlock)successCallback {
-    
+
     NSLog(@"Try open view");
-    
+
     if ([options objectForKey:@"url"] && [options objectForKey:@"url"] != [NSNull null]) {
         NSString *url = [NSString stringWithFormat:@"https://plus.google.com/share?url=%@", options[@"url"]];
         NSURL *gplusURL = [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
-        
+
         if ([[UIApplication sharedApplication] canOpenURL: gplusURL]) {
             [[UIApplication sharedApplication] openURL:gplusURL];
+            successCallback(@[]);
         } else {
             // Cannot open gplus
             NSLog(@"error web intent");

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -22,6 +22,7 @@
 
         if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
             [[UIApplication sharedApplication] openURL: whatsappURL];
+            successCallback(@[]);
         } else {
           // Cannot open whatsapp
           NSString *stringURL = @"http://itunes.apple.com/en/app/whatsapp-messenger/id310633997";


### PR DESCRIPTION
I added promise rejection before.  Now adding promise success to round it out.