### PR TITLE
Add podspec declaration

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -1,0 +1,18 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "RNShare"
+  s.version      = package["version"]
+  s.summary      = "Social Share, Sending Simple Data to Other Apps"
+  s.homepage     = "https://github.com/EstebanFuentealba/react-native-share"
+  s.license      = "MIT"
+  s.author             = { "Esteban Fuentealba" => "fuentealba@json.cl" }
+  s.platform     = :ios, "8.0"
+  s.source       = { :git => "https://github.com/EstebanFuentealba/react-native-share.git", :tag => "#{s.version}" }
+
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+end


### PR DESCRIPTION
Podscpec file for adding this dependency to a native iOS project using React Native and Cocoapods. I manage pod version with the version declare in package.json. To test my PR, you have to create a git tag 1.0.16. 

**You will have to create git tag for each version you 'll release**

Just add this in the Podfile after _pod React_

```
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
       'Core',
       'RCTText',
       'RCTWebSocket', # needed for debugging
       'RCTNetwork'
       # Add any other subspecs you want to use in your project
   ]

   pod 'RNShare', :path => './node_modules/react-native-share'
```
