### PR TITLE
Remove width and height when the overlay is invisible

### DIFF
--- a/components/Overlay.js
+++ b/components/Overlay.js
@@ -18,6 +18,8 @@ const styles = StyleSheet.create({
         position: 'absolute'
     },
     emptyOverlay: {
+        width: 0,
+        height: 0,
         backgroundColor: 'transparent',
         position: 'absolute'
     }


### PR DESCRIPTION
Improved version based on #91 