### PR TITLE
Fix share dialog title missing in android

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -31,6 +31,10 @@ public abstract class ShareIntent {
         if (ShareIntent.hasValidKey("subject", options) ) {
             this.getIntent().putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));
         }
+        
+        if (ShareIntent.hasValidKey("title", options) ) {
+            this.chooserTitle = options.getString("title");
+        }
 
         if (ShareIntent.hasValidKey("message", options) && ShareIntent.hasValidKey("url", options)) {
             ShareFile fileShare = getFileShare(options);


### PR DESCRIPTION
When open the share dialog, the default title is "Share". This a quick fix to able to change the default title.