### PR TITLE
Removed override notation of deprecated method (createJSModules) of React Native 0.47.0

### DIFF
--- a/android/src/main/java/cl/json/RNSharePackage.java
+++ b/android/src/main/java/cl/json/RNSharePackage.java
@@ -15,7 +15,7 @@ public class RNSharePackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNShareModule(reactContext));
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Hi,

Due to https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8 's breaking change, we should remove the override notation of deprecated method `createJSModules`.

Thank you.
