### PR TITLE
Remove createJSModules @Override

### DIFF
--- a/android/src/main/java/cl/json/RNSharePackage.java
+++ b/android/src/main/java/cl/json/RNSharePackage.java
@@ -15,7 +15,7 @@ public class RNSharePackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNShareModule(reactContext));
     }
 
-    @Override
+    // Deprecated in React Native .47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModule was removed in React Native 0.47. By removing the override annotation this now compiles correctly again in all versions of React Native.