### PR TITLE
Fix breaking change for RN 0.47

### DIFF
--- a/android/src/main/java/cl/json/RNSharePackage.java
+++ b/android/src/main/java/cl/json/RNSharePackage.java
@@ -15,11 +15,6 @@ public class RNSharePackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNShareModule(reactContext));
     }
 
-    // Deprecated from RN 0.47.0
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  BackAndroid,
+  BackAndroid as DeprecatedBackAndroid, BackHandler as ModernBackHandler,
   NativeModules,
   Platform,
   ActionSheetIOS,
@@ -14,6 +14,7 @@ import Overlay from './components/Overlay';
 import Sheet from './components/Sheet';
 import Button from './components/Button';
 
+const BackHandler = ModernBackHandler || DeprecatedBackAndroid;
 const styles = StyleSheet.create({
     actionSheetContainer: {
       flex: 1,
@@ -74,7 +75,7 @@ class RNShare {
 }
 class ShareSheet extends React.Component {
   componentDidMount() {
-    BackAndroid.addEventListener('hardwareBackPress',() => {
+    BackHandler.addEventListener('hardwareBackPress',() => {
       if (this.props.visible) {
         this.props.onCancel();
         return true;


### PR DESCRIPTION
Removed reference to createJSModules() which breaks Android builds. 

See [facebook/react-native@ce6fb33](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)