### PR TITLE
Save share files to app images directory

### DIFF
--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -123,7 +123,7 @@ public class ShareFile {
         if(this.isBase64File()) {
             String encodedImg = this.uri.getSchemeSpecificPart().substring(this.uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
             try {
-                File dir = new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_DOWNLOADS );
+                File dir = new File(this.reactContext.getFilesDir(), "images");
                 if (!dir.exists()) {
                     dir.mkdirs();
                 }


### PR DESCRIPTION
This uses a directory within the app in order to read and write files to share with the React Native app. The alleviates some file permissions issues.