### PR TITLE
[Android] Add functionality to show apps that can view a file

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -5,11 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.content.pm.ResolveInfo;
+import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 import java.net.URLEncoder;
 
 import cl.json.ShareFile;
@@ -22,21 +25,25 @@ public abstract class ShareIntent {
     protected final ReactApplicationContext reactContext;
     protected Intent intent;
     protected String chooserTitle = "Share";
+    protected ShareFile fileShare;
+    protected ReadableMap options;
     public ShareIntent(ReactApplicationContext reactContext) {
         this.reactContext = reactContext;
         this.setIntent(new Intent(android.content.Intent.ACTION_SEND));
         this.getIntent().setType("text/plain");
     }
     public void open(ReadableMap options) throws ActivityNotFoundException {
+        this.options = options;
+        this.fileShare = getFileShare(options);
+
         if (ShareIntent.hasValidKey("subject", options) ) {
             this.getIntent().putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));
         }
 
         if (ShareIntent.hasValidKey("message", options) && ShareIntent.hasValidKey("url", options)) {
-            ShareFile fileShare = getFileShare(options);
-            if(fileShare.isFile()) {
-                Uri uriFile = fileShare.getURI();
-                this.getIntent().setType(fileShare.getType());
+            if(this.fileShare.isFile()) {
+                Uri uriFile = this.fileShare.getURI();
+                this.getIntent().setType(this.fileShare.getType());
                 this.getIntent().putExtra(Intent.EXTRA_STREAM, uriFile);
                 this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("message"));
                 this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
@@ -44,10 +51,9 @@ public abstract class ShareIntent {
                 this.getIntent().putExtra(Intent.EXTRA_TEXT, options.getString("message") + " " + options.getString("url"));
             }
         } else if (ShareIntent.hasValidKey("url", options)) {
-            ShareFile fileShare = getFileShare(options);
-            if(fileShare.isFile()) {
-                Uri uriFile = fileShare.getURI();
-                this.getIntent().setType(fileShare.getType());
+            if(this.fileShare.isFile()) {
+                Uri uriFile = this.fileShare.getURI();
+                this.getIntent().setType(this.fileShare.getType());
                 this.getIntent().putExtra(Intent.EXTRA_STREAM, uriFile);
                 this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             } else {
@@ -71,11 +77,38 @@ public abstract class ShareIntent {
             throw new RuntimeException("URLEncoder.encode() failed for " + param);
         }
     }
+    protected Intent[] getIntentsToViewFile(Intent intent, Uri uri) {
+        PackageManager pm = this.reactContext.getPackageManager();
+
+        List<ResolveInfo> resInfo = pm.queryIntentActivities(intent, 0);
+        Intent[] extraIntents = new Intent[resInfo.size()];
+        for (int i = 0; i < resInfo.size(); i++) {
+            ResolveInfo ri = resInfo.get(i);
+            String packageName = ri.activityInfo.packageName;
+
+            Intent newIntent = new Intent();
+            newIntent.setComponent(new ComponentName(packageName, ri.activityInfo.name));
+            newIntent.setAction(Intent.ACTION_VIEW);
+            newIntent.setDataAndType(uri, intent.getType());
+            newIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            extraIntents[i] = new Intent(newIntent);
+        }
+
+        return extraIntents;
+    }
     protected void openIntentChooser() throws ActivityNotFoundException {
-        System.out.println(this.getIntent());
-        System.out.println(this.getIntent().getExtras());
         Intent chooser = Intent.createChooser(this.getIntent(), this.chooserTitle);
         chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        if (ShareIntent.hasValidKey("showAppsToView", options)) {
+            Intent viewIntent = new Intent(Intent.ACTION_VIEW);
+            viewIntent.setType(this.fileShare.getType());
+
+            Intent[] viewIntents = this.getIntentsToViewFile(viewIntent, this.fileShare.getURI());
+
+            chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, viewIntents);
+        }
+
         this.reactContext.startActivity(chooser);
     }
     protected boolean isPackageInstalled(String packagename, Context context) {


### PR DESCRIPTION
My case was that I was sharing a PDF and the list would show only apps like "WhatsApp", "Gmail", etc and I needed to also show PDF viewers as "Acrobat Reader".

I added the option `showAppsToView` which is Android-only (I didn't need for iOS) that shows apps that can open/view the file being shared and can be triggered like this:

```js
Share.open({
  url: '/path/to/pdf',
  type: 'application/pdf',
  showAppsToView: true,
});
```